### PR TITLE
[wip] Basic Cart configuration support

### DIFF
--- a/src/Forms/CartForm.jsx
+++ b/src/Forms/CartForm.jsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+
+import Button from "../components/Button/Button.jsx";
+import Icon from "../components/Icon/Icon.jsx";
+import Group from "../components/Group/Group.jsx";
+import Link from "../components/Link/Link.jsx";
+import Section from "../components/Section/Section.jsx";
+import Text from "../components/Text/Text.jsx";
+import TextInput from "../components/TextInput/TextInput.jsx";
+import Select from "../components/Select/Select.jsx";
+
+class CartForm extends React.Component {
+  static CURRENCIES = [
+    { value: "gbp", label: "GBP" },
+    { value: "usd", label: "USD" }
+  ];
+
+  render() {
+    return (
+      <>
+        <Group direction="column" spacing={0}>
+          <Section position="first">
+            <Text size={16} color="dark">
+              Cart configuration
+            </Text>
+          </Section>
+          <Section position="middle">
+            <Group direction="column">
+              <Group
+                direction="row"
+                alignment={{
+                  justifyContent: "space-between",
+                  alignItems: "center"
+                }}
+              >
+                <Text size={12} color="dark">
+                  Item description
+                </Text>
+                <TextInput
+                  value={this.props.itemDescription}
+                  onChange={this.props.onChangeItemDescription}
+                />
+              </Group>
+              <Group
+                direction="row"
+                alignment={{
+                  justifyContent: "space-between",
+                  alignItems: "center"
+                }}
+              >
+                <Text size={12} color="dark">
+                  Charge amount
+                </Text>
+                <TextInput
+                  value={this.props.chargeAmount}
+                  onChange={this.props.onChangeChargeAmount}
+                />
+              </Group>
+              <Group
+                direction="row"
+                alignment={{
+                  justifyContent: "space-between",
+                  alignItems: "center"
+                }}
+              >
+                <Text size={12} color="dark">
+                  Tax amount
+                </Text>
+                <TextInput
+                  value={this.props.taxAmount}
+                  onChange={this.props.onChangeTaxAmount}
+                />
+              </Group>
+              <Group
+                direction="row"
+                alignment={{
+                  justifyContent: "space-between",
+                  alignItems: "center"
+                }}
+              >
+                <Text size={12} color="dark">
+                  Currency
+                </Text>
+                <Select
+                  items={CartForm.CURRENCIES}
+                  value={CartForm.CURRENCIES[0]}
+                  onChange={this.props.onChangeCurrency}
+                />
+              </Group>
+              <Button
+                color="white"
+                onClick={this.props.onClickUpdateLineItems}
+                disabled={this.props.workflowDisabled}
+              >
+                <Group direction="row">
+                  <Icon icon="list" />
+                  <Text color="blue" size={14}>
+                    Update line items and totals
+                  </Text>
+                </Group>
+              </Button>
+            </Group>
+          </Section>
+          <Section position="last">
+            <Text size={12} color="lightGrey">
+              Test payment responses{" "}
+              <Link
+                href="https://stripe.com/docs/terminal/testing"
+                text="using amounts"
+                newWindow
+              />
+              .
+            </Text>
+          </Section>
+        </Group>
+      </>
+    );
+  }
+}
+
+export default CartForm;

--- a/src/Forms/CommonWorkflows.jsx
+++ b/src/Forms/CommonWorkflows.jsx
@@ -9,44 +9,12 @@ import Section from "../components/Section/Section.jsx";
 import Text from "../components/Text/Text.jsx";
 
 class CommonWorkflows extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      workFlowInProgress: null
-    };
-  }
-
-  runWorkflow = async (workflowName, workflowFn) => {
-    this.setState({
-      workFlowInProgress: workflowName
-    });
-    try {
-      await workflowFn();
-    } finally {
-      this.setState({
-        workFlowInProgress: null
-      });
-    }
-  };
-
-  onRunUpdateLineItemsWorkflow = () => {
-    this.runWorkflow("updateLineItems", this.props.onClickUpdateLineItems);
-  };
-
-  onRunCollectPaymentWorkflow = () => {
-    this.runWorkflow("collectPayment", this.props.onClickCollectCardPayments);
-  };
-
-  onRunSaveCardWorkflow = () => {
-    this.runWorkflow("collectPayment", this.props.onClickSaveCardForFutureUse);
-  };
-
-  isWorkflowDisabled = () =>
-    this.props.cancelablePayment || this.state.workFlowInProgress;
-
   render() {
-    const { onClickCancelPayment, cancelablePayment } = this.props;
+    const {
+      onClickCancelPayment,
+      cancelablePayment,
+      workFlowDisabled
+    } = this.props;
     return (
       <Section>
         <Group direction="column" spacing={16}>
@@ -56,20 +24,8 @@ class CommonWorkflows extends React.Component {
           <Group direction="column" spacing={8}>
             <Button
               color="white"
-              onClick={this.onRunUpdateLineItemsWorkflow}
-              disabled={this.isWorkflowDisabled()}
-            >
-              <Group direction="row">
-                <Icon icon="list" />
-                <Text color="blue" size={14}>
-                  Update line items and totals
-                </Text>
-              </Group>
-            </Button>
-            <Button
-              color="white"
-              onClick={this.onRunCollectPaymentWorkflow}
-              disabled={this.isWorkflowDisabled()}
+              onClick={this.props.onClickCollectCardPayments}
+              disabled={workFlowDisabled}
             >
               <Group direction="row">
                 <Icon icon="payments" />
@@ -80,8 +36,8 @@ class CommonWorkflows extends React.Component {
             </Button>
             <Button
               color="white"
-              onClick={this.onRunSaveCardWorkflow}
-              disabled={this.isWorkflowDisabled()}
+              onClick={this.props.onClickSaveCardForFutureUse}
+              disabled={workFlowDisabled}
             >
               <Group direction="row">
                 <Icon icon="card" />

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+class Select extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { value: this.props.value };
+  }
+
+  onChange = e => {
+    this.setState({ value: e.target.value });
+    this.props.onChange(e.target.value);
+  };
+
+  render() {
+    const items = this.props.items.map((item, index) => (
+      <option key={index} value={item.value}>
+        {item.label}
+      </option>
+    ));
+
+    return (
+      <select value={this.state.value} onChange={this.onChange}>
+        {items}
+      </select>
+    );
+  }
+}
+
+export default Select;


### PR DESCRIPTION
Hi folks! New Stripe.

I grabbed a couple of Terminal devices on my way out of San Francisco and wanted to have a play around with them to build some familiarity. Kudos on the getting started documentation and the helpful example backend – that got me going in no time.

I thought it might be useful to be able to modify the reader display configuration dynamically, and pass that onto the backend. If nothing else, it would make it possible to test the various decline codes using the demonstration app.

![Stripe Terminal demo with cart configuration](https://user-images.githubusercontent.com/50152098/57392580-15320980-71b9-11e9-822f-431548e02e3b.png)

![IMG_3374](https://user-images.githubusercontent.com/50152098/57393203-8a520e80-71ba-11e9-9ab6-dc3c1d86ae16.jpg)

### Changes
- Added `CartForm` component which handles cart display config. Moved the `updateLineItems` workflow to the `CartForm` component.
- Moved `workFlow` functionality to parent component so it can be better shared between `CartForm` and `CommonWorkflows` components. Definitely open to how this can be handled better!
- Added `Select` component for currencies.
- `SetReaderDisplay` and `PaymentIntent` methods dynamically hydrated.