### PR TITLE
Null out PI when you cancelCollectPayment.

### DIFF
--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -279,6 +279,7 @@ class App extends Component {
   // Note this can only be done before calling `processPayment`.
   cancelPendingPayment = async () => {
     await this.terminal.cancelCollectPaymentMethod();
+    this.pendingPaymentIntentSecret = null;
     this.setState({ cancelablePayment: false });
   };
 


### PR DESCRIPTION
Summary:
There was a small bug in the example app where, even if you canceled inbetween collectpaymentMethod calls, calling collectPaymentMethod would not update the amount you wanted to collect (assuming you changed it). This was becuase we were not recreating a new payment intent each time you called collectPaymentIntent so we just use the previously created PI which was incorrect.

Now we null out pendingPaymentIntentSecret so when you go to collectPaymentMethod we create a new PI.

Testing:
1. Connect your reader.
2. Click "Collect card payment", reader should show 53.00 GBP.
3. Update "Charge Amount" to 100.
4. Click "Collect card payment", reader should show 2.00 GBP.

** You can also confirm in the logs that createPaymentIntent is being called twice.