### PR TITLE
keyboard and screenreader a11y improvements

### DIFF
--- a/src/ConnectionInfo/ConnectionInfo.jsx
+++ b/src/ConnectionInfo/ConnectionInfo.jsx
@@ -76,7 +76,7 @@ class ConnectionInfo extends React.Component {
             <Group direction="row">
               <Icon icon="keypad" />
               <Text color="lightGrey" size={14}>
-                Connect to a reader
+                No reader connected
               </Text>
             </Group>
           )}

--- a/src/Forms/BackendURLForm.jsx
+++ b/src/Forms/BackendURLForm.jsx
@@ -16,7 +16,8 @@ class BackendURLForm extends React.Component {
     };
   }
 
-  onClickInitialize = () => {
+  onFormInitialize = (event) => {
+    event.preventDefault();
     this.props.onSetBackendURL(this.state.backendURL.trim());
   };
 
@@ -28,43 +29,46 @@ class BackendURLForm extends React.Component {
     const { backendURL } = this.state;
     return (
       <Section>
-        <Group direction="column" spacing={18}>
-          <Text size={16} color="dark">
-            Connect to backend server
-          </Text>
+        <form onSubmit={this.onFormInitialize}>
+          <Group direction="column" spacing={18}>
+            <Text size={16} color="dark">
+              Connect to backend server
+            </Text>
 
-          <Group direction="column">
-            <TextInput
-              placeholder="https://yourserver.herokuapp.com"
-              value={backendURL}
-              onChange={this.onChangeBackendURL}
-            />
+            <Group direction="column">
+              <TextInput
+                placeholder="https://yourserver.herokuapp.com"
+                value={backendURL}
+                ariaLabel="Backend URL"
+                onChange={this.onChangeBackendURL}
+              />
 
-            <Group
-              direction="row"
-              alignment={{ justifyContent: "space-between" }}
-            >
-              <Text size={12} color="lightGrey">
-                Set up and deploy{" "}
-                <Link
-                  href="https://github.com/stripe/example-terminal-backend"
-                  text="example backend"
-                  newWindow
-                />
-                , then fill in the URL.
-              </Text>
-              <Button
-                onClick={this.onClickInitialize}
-                disabled={backendURL === "" || backendURL === null}
-                color="primary"
+              <Group
+                direction="row"
+                alignment={{ justifyContent: "space-between" }}
               >
-                <Text color="white" size={14}>
-                  Connect
+                <Text size={12} color="lightGrey">
+                  Set up and deploy{" "}
+                  <Link
+                    href="https://github.com/stripe/example-terminal-backend"
+                    text="example backend"
+                    newWindow
+                  />
+                  , then fill in the URL.
                 </Text>
-              </Button>
+                <Button
+                  disabled={backendURL === "" || backendURL === null}
+                  color="primary"
+                  type="submit"
+                >
+                  <Text color="white" size={14}>
+                    Connect
+                  </Text>
+                </Button>
+              </Group>
             </Group>
           </Group>
-        </Group>
+        </form>
       </Section>
     );
   }

--- a/src/Forms/CartForm.jsx
+++ b/src/Forms/CartForm.jsx
@@ -39,6 +39,7 @@ class CartForm extends React.Component {
                 <TextInput
                   value={this.props.itemDescription}
                   onChange={this.props.onChangeItemDescription}
+                  ariaLabel="Item description"
                 />
               </Group>
               <Group
@@ -54,6 +55,7 @@ class CartForm extends React.Component {
                 <TextInput
                   value={this.props.chargeAmount}
                   onChange={this.props.onChangeChargeAmount}
+                  ariaLabel="Charge amount"
                 />
               </Group>
               <Group
@@ -69,6 +71,7 @@ class CartForm extends React.Component {
                 <TextInput
                   value={this.props.taxAmount}
                   onChange={this.props.onChangeTaxAmount}
+                  ariaLabel="Tax amount"
                 />
               </Group>
               <Group
@@ -85,6 +88,7 @@ class CartForm extends React.Component {
                   items={CartForm.CURRENCIES}
                   value={CartForm.CURRENCIES[0]}
                   onChange={this.props.onChangeCurrency}
+                  ariaLabel="Currency"
                 />
               </Group>
               <Button

--- a/src/Forms/Readers.jsx
+++ b/src/Forms/Readers.jsx
@@ -28,7 +28,7 @@ class Readers extends React.Component {
     const {
       readers,
       onClickDiscover,
-      onClickRegister,
+      onSubmitRegister,
       onConnectToReader,
       handleUseSimulator
     } = this.props;
@@ -47,7 +47,7 @@ class Readers extends React.Component {
         return (
           <RegisterNewReader
             onClickCancel={this.handleSwitchToDiscover}
-            onClickRegister={onClickRegister}
+            onSubmitRegister={onSubmitRegister}
           />
         );
       default:

--- a/src/Forms/RegisterNewReader.jsx
+++ b/src/Forms/RegisterNewReader.jsx
@@ -26,9 +26,10 @@ class RegisterNewReader extends React.Component {
     this.setState({ readerLabel: str });
   };
 
-  onClickRegister = () => {
+  onSubmitRegister = (event) => {
+    event.preventDefault();
     const { readerCode, readerLabel } = this.state;
-    this.props.onClickRegister(readerLabel, readerCode);
+    this.props.onSubmitRegister(readerLabel, readerCode);
   };
 
   render() {
@@ -36,56 +37,60 @@ class RegisterNewReader extends React.Component {
     const { onClickCancel } = this.props;
     return (
       <Section>
-        <Group direction="column" spacing={16}>
-          <Group direction="column" spacing={8}>
-            <Text size={16} color="dark">
-              Register new reader
-            </Text>
-            <Text size={12} color="lightGrey">
-              Enter the key sequence 0-7-1-3-9 on the reader to display its
-              unique registration code.
-            </Text>
-          </Group>
-          <Group direction="column" spacing={8}>
-            <Text size={14} color="darkGrey">
-              Registration code
-            </Text>
-            <TextInput
-              placeholder="quick-brown-fox"
-              value={readerCode}
-              onChange={this.onChangeReaderCode}
-            />
-            <Text size={14} color="darkGrey">
-              Reader label
-            </Text>
-            <TextInput
-              placeholder="Front desk"
-              value={readerLabel}
-              onChange={this.onChangeReaderLabel}
-            />
-          </Group>
-          <Group direction="row" alignment={{ justifyContent: "flex-end" }}>
-            <Button color="white" onClick={onClickCancel}>
-              <Text color="darkGrey" size={14}>
-                Cancel
+        <form onSubmit={this.onSubmitRegister}>
+          <Group direction="column" spacing={16}>
+            <Group direction="column" spacing={8}>
+              <Text size={16} color="dark">
+                Register new reader
               </Text>
-            </Button>
-            <Button
-              onClick={this.onClickRegister}
-              disabled={
-                readerCode === null ||
-                readerCode === "" ||
-                readerLabel === null ||
-                readerCode === ""
-              }
-              color="primary"
-            >
-              <Text color="white" size={14}>
-                Register
+              <Text size={12} color="lightGrey">
+                Enter the key sequence 0-7-1-3-9 on the reader to display its
+                unique registration code.
               </Text>
-            </Button>
+            </Group>
+            <Group direction="column" spacing={8}>
+              <Text size={14} color="darkGrey">
+                Registration code
+              </Text>
+              <TextInput
+                placeholder="quick-brown-fox"
+                value={readerCode}
+                onChange={this.onChangeReaderCode}
+                ariaLabel="Registration code"
+              />
+              <Text size={14} color="darkGrey">
+                Reader label
+              </Text>
+              <TextInput
+                placeholder="Front desk"
+                value={readerLabel}
+                onChange={this.onChangeReaderLabel}
+                ariaLabel="Reader label"
+              />
+            </Group>
+            <Group direction="row" alignment={{ justifyContent: "flex-end" }}>
+              <Button color="white" onClick={onClickCancel}>
+                <Text color="darkGrey" size={14}>
+                  Cancel
+                </Text>
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  readerCode === null ||
+                  readerCode === "" ||
+                  readerLabel === null ||
+                  readerCode === ""
+                }
+                color="primary"
+              >
+                <Text color="white" size={14}>
+                  Register
+                </Text>
+              </Button>
+            </Group>
           </Group>
-        </Group>
+        </form>
       </Section>
     );
   }

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -328,7 +328,7 @@ class App extends Component {
       return (
         <Readers
           onClickDiscover={() => this.discoverReaders(false)}
-          onClickRegister={this.registerAndConnectNewReader}
+          onSubmitRegister={this.registerAndConnectNewReader}
           readers={discoveredReaders}
           onConnectToReader={this.connectToReader}
           handleUseSimulator={this.connectToSimulator}

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -49,12 +49,14 @@ class Button extends React.Component {
           transition: all 0.2s ease;
           padding: 0;
 
-          :hover {
+          :hover, :focus {
             color: #9fcdff;
           }
 
           :focus {
             outline: 0;
+            box-shadow: 0 0 0 2px rgba(6,122,184, 0.2),
+            0 0 0 2px rgba(6,122,184, 0.25), 0 1px 1px rgba(0, 0, 0, 0.08);
           }
         `;
       case "primary":
@@ -83,25 +85,28 @@ class Button extends React.Component {
             opacity: 0.5;
           }
 
-          :hover {
+          :hover, :focus {
             background-color: ${this.getButtonHoverColor(type)};
           }
 
           :focus {
             outline: 0;
+            box-shadow: 0 0 0 2px rgba(6,122,184, 0.2),
+            0 0 0 2px rgba(6,122,184, 0.25), 0 1px 1px rgba(0, 0, 0, 0.08);
           }
         `;
     }
   };
 
   render() {
-    const { children, disabled, onClick, color } = this.props;
+    const { children, disabled, onClick, color, type } = this.props;
 
     return (
       <button
         className={this.getButtonStyles(color)}
         onClick={onClick}
         disabled={disabled}
+        type={type || "button"}
       >
         {children}
       </button>

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -29,7 +29,7 @@ const ICONS = {
 class Icon extends React.Component {
   render() {
     const { icon } = this.props;
-    return <object data={ICONS[icon]}>""</object>;
+    return <object data={ICONS[icon]} tabIndex="-1">""</object>;
   }
 }
 

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -8,13 +8,14 @@ class TextInput extends React.Component {
   };
 
   render() {
-    const { placeholder, value } = this.props;
+    const { placeholder, value, ariaLabel } = this.props;
     return (
       <input
         placeholder={placeholder}
         value={value || ""}
         onChange={this.onChange}
         className="TextInput"
+        aria-label={ariaLabel || ""}
       />
     );
   }


### PR DESCRIPTION
Hello 👋 

I did a shallow pass over the experience of navigating the frontend of this demo app with a keyboard and additionally also with a screenreader. There were a few issues I ran into which I took the liberty of fixing:

1. ⌨️ Tabbing functionality kept getting stuck on the SVG icons on the page, with no way to escape out and continue. I gave them negative tabindex in order to allow tab order to skip them as they're non functional elements on the page.

2. 🔘 Some buttons and links did not have a keyboard focus style on them, due to some `outline: 0` css styling. I borrowed the focus ring style from the TextInput component in order to help stay consistent but also allow users to see when their keyboard tabbing focus is on a button / link. I have attached a GIF showing that you can now tab through and all tabbable elements change visual state to show which element currently has focus.

3. 🏷Most form input elements had no matching label tags. So when using a screenreader, there wasn't any description read out of what the field is for. I added some `aria-label` attribute as it disturbed the markup the least amount to get these inputs adequately described. I have attached a before and after screenshot example below.

4. 📋Most of the form components did not have a form tag present. This meant that hitting enter on any form field other than a button had no action performed. This is an accessibility issue, so I went ahead and added form elements and moved the action performed to the submit event instead of replying on someone activating the required button at the end of the form.

A GIF showing correct tabbing order with visible styling and no SVG icon focus trapping:

![terminal-tab-order](https://user-images.githubusercontent.com/54524269/65074475-c310aa00-d949-11e9-91e2-6e660cae302a.gif)

And here is a before and after of what [Voiceover](https://www.apple.com/accessibility/mac/vision/) says when focusing on a text input:

Before:
<img width="356" alt="a11y-terminal-before" src="https://user-images.githubusercontent.com/54524269/65074621-1256da80-d94a-11e9-9bab-731d81deb69a.png">

After:
<img width="354" alt="a11y-terminal-after" src="https://user-images.githubusercontent.com/54524269/65074630-171b8e80-d94a-11e9-967d-ad28efe76fdc.png">

I have some other feedback with regards to further accessibility improvements that we could potentially make, but I'll save that for a separate feedback document.

Thanks 🙇 



