### PR TITLE
allow cancellation of discovery + disable buttons during active requests

### DIFF
--- a/src/Forms/DiscoverReaders.jsx
+++ b/src/Forms/DiscoverReaders.jsx
@@ -13,28 +13,19 @@ class DiscoverReaders extends React.Component {
 
     this.state = {
       discoveryInProgress: false,
-      requestInProgress: false,
-      discoveryWasCancelled: false
+      requestInProgress: false
     };
   }
 
+  onTriggerCancelDiscoverReaders = () => {
+    this.setState({ discoveryInProgress: false });
+    this.props.onClickCancelDiscover();
+  }
+
   onTriggerDiscoverReaders = async () => {
-    // user clicked discovery button ("cancel") while already discovering
-    if (this.state.discoveryInProgress) {
-      this.setState({
-        discoveryInProgress: false,
-        requestInProgress: false,
-        discoveryWasCancelled: true
-      });
-
-      return;
-    }
-
-    // user clicked discovery button
     this.setState({
       discoveryInProgress: true,
-      requestInProgress: true,
-      discoveryWasCancelled: false
+      requestInProgress: true
     });
 
     try {
@@ -58,7 +49,7 @@ class DiscoverReaders extends React.Component {
 
   renderReaders() {
     const { readers } = this.props;
-    const { discoveryWasCancelled, requestInProgress, discoveryInProgress } = this.state;
+    const { requestInProgress, discoveryInProgress } = this.state;
 
     if (discoveryInProgress) {
       return (
@@ -68,7 +59,7 @@ class DiscoverReaders extends React.Component {
           </Text>
         </Section>
       );
-    } else if (readers.length >= 1 && !discoveryWasCancelled) {
+    } else if (readers.length >= 1) {
       return readers.map((reader, i) => {
         const isOffline = reader.status === "offline";
         return (
@@ -154,9 +145,11 @@ class DiscoverReaders extends React.Component {
             <Text size={16} color="dark">
               Connect to a reader
             </Text>
-            <Button color="text" onClick={this.onTriggerDiscoverReaders}>
-              {discoveryInProgress ? "Cancel" : "Discover"}
-            </Button>
+            {
+               discoveryInProgress
+               ? <Button color="text" onClick={this.onTriggerCancelDiscoverReaders}>Cancel</Button>
+               : <Button color="text" onClick={this.onTriggerDiscoverReaders} disabled={requestInProgress}>Discover</Button>
+            }
           </Group>
         </Section>
 

--- a/src/Forms/Readers.jsx
+++ b/src/Forms/Readers.jsx
@@ -28,6 +28,7 @@ class Readers extends React.Component {
     const {
       readers,
       onClickDiscover,
+      onClickCancelDiscover,
       onSubmitRegister,
       onConnectToReader,
       handleUseSimulator
@@ -37,6 +38,7 @@ class Readers extends React.Component {
         return (
           <DiscoverReaders
             onClickDiscover={onClickDiscover}
+            onClickCancelDiscover={onClickCancelDiscover}
             onClickRegister={this.onClickRegister}
             onConnectToReader={onConnectToReader}
             readers={readers}

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -29,7 +29,8 @@ class App extends Component {
       itemDescription: "Red t-shirt",
       taxAmount: 100,
       currency: "usd",
-      workFlowInProgress: null
+      workFlowInProgress: null,
+      disoveryWasCancelled: false
     };
   }
 
@@ -143,6 +144,10 @@ class App extends Component {
 
   // 2. Discover and connect to a reader.
   discoverReaders = async () => {
+    this.setState({
+      discoveryWasCancelled: false
+    });
+
     // 2a. Discover registered readers to connect to.
     const discoverResult = await this.terminal.discoverReaders();
 
@@ -150,11 +155,19 @@ class App extends Component {
       console.log("Failed to discover: ", discoverResult.error);
       return discoverResult.error;
     } else {
+      if (this.state.discoveryWasCancelled) return;
+
       this.setState({
         discoveredReaders: discoverResult.discoveredReaders
       });
       return discoverResult.discoveredReaders;
     }
+  };
+
+  cancelDiscoverReaders = () => {
+    this.setState({
+      discoveryWasCancelled: true
+    });
   };
 
   connectToSimulator = async () => {
@@ -332,7 +345,8 @@ class App extends Component {
     } else if (reader === null) {
       return (
         <Readers
-          onClickDiscover={() => this.discoverReaders(false)}
+          onClickDiscover={() => this.discoverReaders()}
+          onClickCancelDiscover={() => this.cancelDiscoverReaders()}
           onSubmitRegister={this.registerAndConnectNewReader}
           readers={discoveredReaders}
           onConnectToReader={this.connectToReader}


### PR DESCRIPTION
This PR does the following:

1. Disables visible buttons when a request is active. Examples of requests include discovering readers, connecting with the simulated device, connecting with a real reader, etc.

![Feb-25-2020 14-23-40](https://user-images.githubusercontent.com/54524269/75293262-b2a70a00-57da-11ea-93a2-388bc13f7482.gif)

![Feb-25-2020 14-24-00](https://user-images.githubusercontent.com/54524269/75293284-b9358180-57da-11ea-9eaa-d10ebee1ff1d.gif)

2. Allows for cancellation of reader discovery. The same button is used to start discovering. The button switches to say "cancel" when clicked and the app is in discovering status.

![Feb-25-2020 14-25-08](https://user-images.githubusercontent.com/54524269/75293295-c0f52600-57da-11ea-9924-d72a145a8491.gif)

Hope you're having a great day 🌻 💯 
