### PR TITLE
adding in support for CZK

### DIFF
--- a/src/Forms/CartForm.jsx
+++ b/src/Forms/CartForm.jsx
@@ -13,6 +13,7 @@ class CartForm extends React.Component {
   static CURRENCIES = [
     { value: "aud", label: "AUD" },
     { value: "cad", label: "CAD" },
+    { value: "czk", label: "CZK" },
     { value: "eur", label: "EUR" },
     { value: "gbp", label: "GBP" },
     { value: "nzd", label: "NZD" },


### PR DESCRIPTION
This change updates the currency list to make it easier to enter/select Czech koruna ( CZK ) when setting up payments.