### PR TITLE
Add on-reader tips

### DIFF
--- a/src/Forms/CommonWorkflows.jsx
+++ b/src/Forms/CommonWorkflows.jsx
@@ -15,6 +15,7 @@ class CommonWorkflows extends React.Component {
       onClickCancelPayment,
       onChangeTestCardNumber,
       onChangeTipAmount,
+      onChangeSimulateOnReaderTip,
       onChangeTestPaymentMethod,
       cancelablePayment,
       workFlowDisabled,
@@ -31,6 +32,7 @@ class CommonWorkflows extends React.Component {
               <TestPaymentMethods
                 onChangeTestCardNumber={onChangeTestCardNumber}
                 onChangeTipAmount={onChangeTipAmount}
+                onChangeSimulateOnReaderTip={onChangeSimulateOnReaderTip}
                 onChangeTestPaymentMethod={onChangeTestPaymentMethod}
               />
             )}

--- a/src/Forms/CommonWorkflows.jsx
+++ b/src/Forms/CommonWorkflows.jsx
@@ -14,6 +14,7 @@ class CommonWorkflows extends React.Component {
     const {
       onClickCancelPayment,
       onChangeTestCardNumber,
+      onChangeTipAmount,
       onChangeTestPaymentMethod,
       cancelablePayment,
       workFlowDisabled,
@@ -29,6 +30,7 @@ class CommonWorkflows extends React.Component {
             {usingSimulator && (
               <TestPaymentMethods
                 onChangeTestCardNumber={onChangeTestCardNumber}
+                onChangeTipAmount={onChangeTipAmount}
                 onChangeTestPaymentMethod={onChangeTestPaymentMethod}
               />
             )}

--- a/src/Forms/TestPaymentMethods.jsx
+++ b/src/Forms/TestPaymentMethods.jsx
@@ -53,6 +53,7 @@ class TestPaymentMethods extends React.Component {
     this.state = {
       testCardNumber: "",
       testPaymentMethod: "visa",
+      tipAmount: "0",
     };
   }
 
@@ -61,13 +62,18 @@ class TestPaymentMethods extends React.Component {
     this.props.onChangeTestCardNumber(testCardNumber);
   };
 
+  onChangeTipAmount = (tipAmount) => {
+    this.setState({ tipAmount });
+    this.props.onChangeTipAmount(tipAmount);
+  };
+
   onChangeTestPaymentMethod = (testPaymentMethod) => {
     this.setState({ testPaymentMethod });
     this.props.onChangeTestPaymentMethod(testPaymentMethod);
   };
 
   render() {
-    const { testCardNumber, testPaymentMethod } = this.state;
+    const { testCardNumber, testPaymentMethod, tipAmount } = this.state;
     return (
       <>
         <Group
@@ -93,6 +99,24 @@ class TestPaymentMethods extends React.Component {
           value={testPaymentMethod}
           onChange={this.onChangeTestPaymentMethod}
         />
+        <Group
+          spacing={4}
+          direction="row"
+          alignment={{
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Text color="dark">Tip Amount</Text>
+          <TextInput
+            ariaLabel="Test Tip Amount"
+            onChange={this.onChangeTipAmount}
+            value={tipAmount}
+            type="number"
+            min="0"
+            step="1"
+          />
+        </Group>
       </>
     );
   }

--- a/src/Forms/TestPaymentMethods.jsx
+++ b/src/Forms/TestPaymentMethods.jsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import Group from "../components/Group/Group.jsx";
 import Text from "../components/Text/Text.jsx";
 import TextInput from "../components/TextInput/TextInput.jsx";
+import CheckBox from "../components/CheckBox/CheckBox.jsx";
 import Select from "../components/Select/Select.jsx";
 
 const middot = "\u00b7";
@@ -53,7 +54,8 @@ class TestPaymentMethods extends React.Component {
     this.state = {
       testCardNumber: "",
       testPaymentMethod: "visa",
-      tipAmount: "0",
+      tipAmount: null,
+      simulateOnReaderTip: false
     };
   }
 
@@ -67,13 +69,18 @@ class TestPaymentMethods extends React.Component {
     this.props.onChangeTipAmount(tipAmount);
   };
 
+  onChangeSimulateOnReaderTip = (simulateOnReaderTip) => {
+    this.setState({ simulateOnReaderTip });
+    this.props.onChangeSimulateOnReaderTip(simulateOnReaderTip);
+  };
+
   onChangeTestPaymentMethod = (testPaymentMethod) => {
     this.setState({ testPaymentMethod });
     this.props.onChangeTestPaymentMethod(testPaymentMethod);
   };
 
   render() {
-    const { testCardNumber, testPaymentMethod, tipAmount } = this.state;
+    const { testCardNumber, testPaymentMethod, tipAmount, simulateOnReaderTip } = this.state;
     return (
       <>
         <Group
@@ -107,16 +114,31 @@ class TestPaymentMethods extends React.Component {
             alignItems: "center",
           }}
         >
+          <Text color="dark">Simulate on-reader tip?</Text>
+          <CheckBox
+            ariaLabel="Simulate on-reader tip?"
+            onChange={this.onChangeSimulateOnReaderTip}
+            value={simulateOnReaderTip}
+          />
+        </Group>
+        {simulateOnReaderTip && <Group
+          spacing={4}
+          direction="row"
+          alignment={{
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
           <Text color="dark">Tip Amount</Text>
           <TextInput
-            ariaLabel="Test Tip Amount"
+            ariaLabel="Tip Amount"
             onChange={this.onChangeTipAmount}
-            value={tipAmount}
+            value={Number(tipAmount).toString()}
             type="number"
             min="0"
             step="1"
           />
-        </Group>
+        </Group>}
       </>
     );
   }

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -38,7 +38,8 @@ class App extends Component {
       usingSimulator: false,
       testCardNumber: "",
       testPaymentMethod: "visa",
-      tipAmount: "0",
+      tipAmount: null,
+      simulateOnReaderTip: false
     };
   }
 
@@ -281,12 +282,20 @@ class App extends Component {
         return;
       }
     }
-    // Read a card from the customer
-    this.terminal.setSimulatorConfiguration({
+
+    
+
+    const simulatorConfiguration = {
       testPaymentMethod: this.state.testPaymentMethod,
-      testCardNumber: this.state.testCardNumber,
-      tipAmount: Number(this.state.tipAmount),
-    });
+      testCardNumber: this.state.testCardNumber
+    };
+
+    if (this.state.simulateOnReaderTip) {
+      simulatorConfiguration.tipAmount = Number(this.state.tipAmount);
+    }
+
+    // Read a card from the customer
+    this.terminal.setSimulatorConfiguration(simulatorConfiguration);
     const paymentMethodPromise = this.terminal.collectPaymentMethod(
       this.pendingPaymentIntentSecret
     );
@@ -429,6 +438,10 @@ class App extends Component {
     this.setState({ tipAmount });
   };
 
+  onChangeSimulateOnReaderTip = (simulateOnReaderTip) => {
+    this.setState({ simulateOnReaderTip });
+  };
+
   renderForm() {
     const {
       backendURL,
@@ -466,6 +479,7 @@ class App extends Component {
             onChangeTestPaymentMethod={this.onChangeTestPaymentMethod}
             onChangeTestCardNumber={this.onChangeTestCardNumber}
             onChangeTipAmount={this.onChangeTipAmount}
+            onChangeSimulateOnReaderTip={this.onChangeSimulateOnReaderTip}
             cancelablePayment={cancelablePayment}
             usingSimulator={usingSimulator}
           />

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -37,7 +37,8 @@ class App extends Component {
       cancelableRefund: false,
       usingSimulator: false,
       testCardNumber: "",
-      testPaymentMethod: "visa"
+      testPaymentMethod: "visa",
+      tipAmount: "0",
     };
   }
 
@@ -283,7 +284,8 @@ class App extends Component {
     // Read a card from the customer
     this.terminal.setSimulatorConfiguration({
       testPaymentMethod: this.state.testPaymentMethod,
-      testCardNumber: this.state.testCardNumber
+      testCardNumber: this.state.testCardNumber,
+      tipAmount: Number(this.state.tipAmount),
     });
     const paymentMethodPromise = this.terminal.collectPaymentMethod(
       this.pendingPaymentIntentSecret
@@ -423,6 +425,10 @@ class App extends Component {
     this.setState({ testCardNumber });
   };
 
+  onChangeTipAmount = (tipAmount) => {
+    this.setState({ tipAmount });
+  };
+
   renderForm() {
     const {
       backendURL,
@@ -459,6 +465,7 @@ class App extends Component {
             onClickCancelPayment={this.cancelPendingPayment}
             onChangeTestPaymentMethod={this.onChangeTestPaymentMethod}
             onChangeTestCardNumber={this.onChangeTestCardNumber}
+            onChangeTipAmount={this.onChangeTipAmount}
             cancelablePayment={cancelablePayment}
             usingSimulator={usingSimulator}
           />

--- a/src/components/CheckBox/CheckBox.css
+++ b/src/components/CheckBox/CheckBox.css
@@ -1,0 +1,3 @@
+.CheckBox:focus {
+    box-shadow: 0 0 0 2px rgba(6,122,184, 0.2), 0 0 0 2px rgba(6,122,184, 0.25), 0 1px 1px rgba(0, 0, 0, 0.08);
+}

--- a/src/components/CheckBox/CheckBox.jsx
+++ b/src/components/CheckBox/CheckBox.jsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import "./CheckBox.css";
+
+class CheckBox extends React.Component {
+  onChange = (e) => {
+    this.props.onChange(e.target.checked);
+  };
+
+  render() {
+    const { ariaLabel, value } = this.props;
+    return (
+      <input
+        value={value || false}
+        onChange={this.onChange}
+        className="CheckBox"
+        aria-label={ariaLabel || ""}
+        type={"checkbox"}
+      />
+    );
+  }
+}
+
+export default CheckBox;

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -8,7 +8,15 @@ class TextInput extends React.Component {
   };
 
   render() {
-    const { placeholder, value, ariaLabel, maxlength } = this.props;
+    const {
+      placeholder,
+      value,
+      ariaLabel,
+      maxlength,
+      type,
+      min,
+      step,
+    } = this.props;
     return (
       <input
         placeholder={placeholder}
@@ -17,6 +25,9 @@ class TextInput extends React.Component {
         className="TextInput"
         aria-label={ariaLabel || ""}
         maxlength={maxlength || ""}
+        type={type || "text"}
+        min={min || ""}
+        step={step || ""}
       />
     );
   }


### PR DESCRIPTION
Hi!
I've added support for on-reader tipping.

### Description
Now you can add tips amount to your payment.
Clicking on "Simulate on-reader tip?" checkbox enables on-reader tips and "Tip Amount" input becomes visible for tips value.


### Screenshot:
![image](https://user-images.githubusercontent.com/91419045/230578462-1c7eaf26-10e6-48a1-ab43-542cd62e7d73.png)

### On-reader tipping docs:
- https://stripe.com/docs/terminal/features/collecting-tips/on-reader
- https://stripe.com/docs/terminal/references/api/js-sdk#stripeterminal-setsimulatorconfig

