### PR TITLE
Reset pending payment intent when changing charge amount

### DIFF
--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -283,7 +283,7 @@ class App extends Component {
       }
     }
 
-    
+
 
     const simulatorConfiguration = {
       testPaymentMethod: this.state.testPaymentMethod,
@@ -414,8 +414,12 @@ class App extends Component {
     this.initializeBackendClientAndTerminal(url);
     this.setState({ backendURL: url });
   };
-  updateChargeAmount = amount =>
+  updateChargeAmount = amount => {
     this.setState({ chargeAmount: parseInt(amount, 10) });
+    // we changed the charge amount, so we need to reset the pending payment intent secret
+    // or else we'll try to use the old payment intent instead of creating a new one
+    this.pendingPaymentIntentSecret = null;
+  };
   updateItemDescription = description =>
     this.setState({ itemDescription: description });
   updateTaxAmount = amount =>


### PR DESCRIPTION
A small bug that came through our bug reporting. Changing the charge amount after a decline would not create a new payment intent but use the previously created one. 

The issue was that we never reset the `pendingPaymentIntentSecret` when the payment amount was changed. We [check](https://github.com/stripe/stripe-terminal-js-demo/blob/25f491459fa634e49141a1d4214ff15d6e44df47/src/MainPage.jsx#L267) for a non-null `pendingPaymentIntentSecret` before creating a new payment intent. Since the previous payment was declined, the `pendingPaymentIntentSecret` was never reset and we never create a new payment intent with the updated charge amount.

Steps to reproduce:
1. create a payment intent ending in 01 so that the payment will be declined as per our [documentation](https://docs.stripe.com/terminal/references/testing#physical-test-cards)
2. collect card payment should charge for the amount set in step 1
3. update the charge amount to a different amount
4. collect card payment should charge the amount set in step 3